### PR TITLE
the real order of arguments is `defaults, options`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ The Node object extending function that Node uses for Node!
 
 ## Usage
 
-```
+```js
 var extend = require('util-extend');
 function functionThatTakesOptions(options) {
-  var options = extend(options, defaults);
+  var options = extend(defaults, options);
   // now any unset options are set to the defaults.
 }
 ```


### PR DESCRIPTION
Because `extend({foo: 'bar'}, {foo: 'bazz'})` returns `{ foo: 'bazz' }`.

Fixes #1.
